### PR TITLE
test: preview pipeline on latest cartesi/docs (do not merge)

### DIFF
--- a/get-started/index.mdx
+++ b/get-started/index.mdx
@@ -4,6 +4,10 @@ Cartesi offers a suite of products and tools that equips developers with access 
 
 import DocCard from '@theme/DocCard';
 
+:::info Preview smoke test (latest docs)
+Temporary note added by a test PR to confirm per-PR previews work against the **latest** cartesi/docs content. Safe to ignore; not for merge.
+:::
+
 ## Dive into Cartesi stack
 
 


### PR DESCRIPTION
Validates the per-PR preview system against the **latest** cartesi/docs content (Docusaurus 3.6.3), now that the fork is re-baselined. Adds a visible `:::info` note to the Get Started landing page. **Do not merge.**