### PR TITLE
docs: hyphenate "high-performance" on the Get Started landing

### DIFF
--- a/get-started/index.mdx
+++ b/get-started/index.mdx
@@ -1,6 +1,6 @@
 # Welcome to Cartesi Docs
 
-Cartesi offers a suite of products and tools that equips developers with access to a full Linux environment and high performance decentralised apps all while preserving the blockchain security guarantees. Select an item below to get started.
+Cartesi offers a suite of products and tools that equips developers with access to a full Linux environment and high-performance decentralised apps all while preserving the blockchain security guarantees. Select an item below to get started.
 
 import DocCard from '@theme/DocCard';
 


### PR DESCRIPTION
A small copy-edit — hyphenates the compound adjective **"high-performance"** on the Get Started landing page.

It also doubles as a **live demo of the per-PR preview deployment**: once CI finishes, a bot will comment with a preview URL where you can browse the rendered docs exactly as they'd look if this were merged. That's the whole point of the system — every PR gets its own throwaway preview site, and it's removed automatically when the PR closes.

Implementation reference: #12 · upstream proposal: cartesi/docs#333
