### PR TITLE
fix(serve-markdown): serve full .md on PR previews (baseUrl-relative paths)

### DIFF
--- a/plugins/serve-markdown.js
+++ b/plugins/serve-markdown.js
@@ -47,6 +47,26 @@ function resolveSource(siteDir, source) {
 }
 
 /**
+ * Strip the site baseUrl from a permalink so paths are baseUrl-relative.
+ *
+ * Docusaurus permalinks include the configured baseUrl, but the build output
+ * (and the URLs people request) are relative to it. Under a sub-path baseUrl —
+ * e.g. GitHub Pages PR previews at /<repo>/pr-preview/pr-<N>/ — using the raw
+ * permalink writes .md files to a baseUrl-nested dead path and breaks the
+ * llms.txt index/alias matching. At baseUrl "/" this is a no-op.
+ *
+ * @param {string} permalink
+ * @param {string} baseUrl   e.g. "/" or "/repo/pr-preview/pr-12/"
+ * @returns {string}
+ */
+function stripBaseUrl(permalink, baseUrl) {
+  if (baseUrl && baseUrl !== '/' && permalink.startsWith(baseUrl)) {
+    return '/' + permalink.slice(baseUrl.length);
+  }
+  return permalink;
+}
+
+/**
  * Walk the allContent object and collect every { permalink → absFilePath }
  * pair from all @docusaurus/plugin-content-docs instances.
  *
@@ -58,9 +78,10 @@ function resolveSource(siteDir, source) {
  *
  * @param {Record<string, Record<string, any>>} allContent
  * @param {string} siteDir
+ * @param {string} baseUrl   site baseUrl; keys are stored baseUrl-relative
  * @returns {Map<string, string>}  permalink → absolute source path
  */
-function buildUrlMap(allContent, siteDir) {
+function buildUrlMap(allContent, siteDir, baseUrl) {
   const map = new Map();
 
   for (const instancesById of Object.values(allContent)) {
@@ -75,9 +96,13 @@ function buildUrlMap(allContent, siteDir) {
         for (const doc of docs) {
           const { permalink, source } = doc;
           if (!permalink || !source) continue;
+          // Store keys baseUrl-relative so the .md output paths and the llms
+          // index/alias routes line up under any baseUrl (incl. sub-path
+          // previews). No-op when baseUrl is "/".
+          const sitePermalink = stripBaseUrl(permalink, baseUrl);
           // Normalize: always store with trailing slash so toPermalink lookups
           // are consistent regardless of how Docusaurus emits the permalink.
-          const normalised = permalink.endsWith('/') ? permalink : permalink + '/';
+          const normalised = sitePermalink.endsWith('/') ? sitePermalink : sitePermalink + '/';
           map.set(normalised, resolveSource(siteDir, source));
         }
       }
@@ -386,7 +411,7 @@ module.exports = function serveMarkdownPlugin(context) {
     // contentLoaded, and before configureWebpack / postBuild.
     //
     async allContentLoaded({ allContent }) {
-      const discovered = buildUrlMap(allContent, siteDir);
+      const discovered = buildUrlMap(allContent, siteDir, siteConfig.baseUrl);
       for (const [permalink, absPath] of discovered) {
         urlMap.set(permalink, absPath);
       }


### PR DESCRIPTION
## Problem

On PR previews (served from a sub-path, e.g. `/<repo>/pr-preview/pr-<N>/`), appending `.md` to a docs URL returned an **empty stub** — just the llms directive and a title — instead of the full page. Production was unaffected.

## Root cause

`plugins/serve-markdown.js` keyed its URL map on `doc.permalink`, and **Docusaurus permalinks include the site `baseUrl`**. So in `postBuild`:
- At `baseUrl: "/"` (production) → writes `build/get-started/quickstart.md` ✅
- Under a sub-path `baseUrl` (previews) → writes the full `.md` to a dead nested path `build/<baseUrl>/get-started/quickstart.md`, and the generated-index fallback then dropped a **title-only stub** at the real URL.

(Confirmed: on a preview, the full content was retrievable at the baseUrl-nested path, while `…/get-started/quickstart.md` served only the 115-byte stub.)

## Fix

Normalize permalinks to **baseUrl-relative** in `buildUrlMap` (one place). This corrects the `.md` output paths, the `llms.txt` index/alias route matching, and the `llms-full.txt` page URLs together. It's a **no-op at `baseUrl: "/"`**, so production behavior is unchanged.

## Verification

This PR targets `main`, so its own preview will deploy — appending `.md` to a page on that preview should now return the **full** markdown (not a stub).
